### PR TITLE
build(stylecop) better consistency with warnings and errors

### DIFF
--- a/stylecop.json
+++ b/stylecop.json
@@ -2,12 +2,6 @@
   "$schema":
     "https://raw.githubusercontent.com/DotNetAnalyzers/StyleCopAnalyzers/master/StyleCop.Analyzers/StyleCop.Analyzers/Settings/stylecop.schema.json",
   "settings": {
-    "layoutRules": {
-      "newlineAtEndOfFile": "omit"
-    },
-    "orderingRules": {
-      "blankLinesBetweenUsingGroups": "omit"
-    },
     "indentation": {
       "tabSize": 2,
       "indentationSize": 2

--- a/stylecop.ruleset
+++ b/stylecop.ruleset
@@ -3,7 +3,7 @@
          Description="These rules focus on the most critical problems in your code, including potential security holes, application crashes, and other important logic and design errors. It is recommended to include this rule set in any custom rule set you create for your projects."
          ToolsVersion="10.0">
   <Rules AnalyzerId="Microsoft.Analyzers.ManagedCodeAnalysis" RuleNamespace="Microsoft.Rules.Managed">
-    <Rule Id="CS0219" Action="Error"/>
+    <Rule Id="CS0219" Action="Warning"/>
     <Rule Id="CA1001" Action="Warning"/>
     <Rule Id="CA1009" Action="Warning"/>
     <Rule Id="CA1016" Action="Warning"/>
@@ -21,7 +21,7 @@
     <Rule Id="CA1405" Action="Warning"/>
     <Rule Id="CA1410" Action="Warning"/>
     <Rule Id="CA1415" Action="Warning"/>
-    <Rule Id="CA1801" Action="Error"/>
+    <Rule Id="CA1801" Action="Warning"/>
     <Rule Id="CA1821" Action="Warning"/>
     <Rule Id="CA1822" Action="None"/>
     <Rule Id="CA1900" Action="Warning"/>


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/igroup-opole/yesterday-api/blob/master/CONTRIBUTING.md
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)


## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[ ] Bugfix
[ ] Feature
[x] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Other... Please describe:
```

## What is the new behavior?

I would like to be more consistance with our stylecop configuration. Rules from .json was reduntant. Rules from .ruleset now are never errors. For now we don't know exactly still what we need so it's better to have just warning. Maybe in the future better solution would be to have some error rules link 'unused field / param'.

Here's were I've found this configuration - https://github.com/Microsoft/aspnet-api-versioning/blob/master/tools/code-analysis.ruleset

## Does this PR introduce a breaking change?
```
[ ] Yes
[x] No
```